### PR TITLE
Remove "Downloadable" from Apple Music

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Enhancements for [RateYourMusic](https://rateyourmusic.com/) 🎧
 ## Contributing
 
 I take any and all PRs. So far I've worked with a few talented developers and would love to work with more:
+
 - ~lempamo: additional collection filters, label autofill, inline profile editing/markup preview, advanced autofill options, and speed/size optimizations
 - ~code_gs: collection filters feature
 - ~flushed_emoji: Melon import support
@@ -65,12 +66,8 @@ Use this to generate a production build with minified code.
 # Install dependencies
 yarn
 
-# Build for all browsers
+# Build for all browsers (Chrome and Firefox)
 yarn prod
-
-# Build for individual browsers
-yarn prod:chrome
-yarn prod:firefox
 ```
 
 ## License

--- a/src/common/services/applemusic/resolve.ts
+++ b/src/common/services/applemusic/resolve.ts
@@ -85,7 +85,7 @@ export const resolve: ResolveFunction = async (url) => {
     title = release.attributes.name
     type = getReleaseType(tracks.length)
     format = 'lossless digital'
-    attributes = ['downloadable', 'streaming']
+    attributes = ['streaming']
     if (title?.includes(' - EP')) {
       title = title.replace(' - EP', '')
       type = 'ep'


### PR DESCRIPTION
Apple Music is not the same as the iTunes Store (which I believe is
going away soon). Tracks on Apple Music are encrypted and can only be
played on an apple device that's authorized against that account. So
it's not fair to day these are Downloadable.

https://rateyourmusic.com/admin/corq/?req_id=10106042

Also, removed some build commands for individual browsers in the README.

Fixes #148