### PR TITLE
Quickly add "featured" and "remixer" credits.

### DIFF
--- a/src/common/utils/dom.ts
+++ b/src/common/utils/dom.ts
@@ -70,3 +70,19 @@ export const runScript = (script: string) => {
   document.head.append(element)
   element.remove()
 }
+
+export const waitForResult = (
+  iframe: HTMLIFrameElement
+): Promise<HTMLDivElement | undefined> =>
+  new Promise((resolve) => {
+    const listener = () => {
+      const firstResult =
+        iframe.contentDocument?.querySelector<HTMLDivElement>('div.result')
+
+      if (firstResult != null) resolve(firstResult)
+      else resolve(undefined)
+
+      iframe.removeEventListener('load', listener)
+    }
+    iframe.addEventListener('load', listener)
+  })

--- a/src/modules/release-submission/components/credits.tsx
+++ b/src/modules/release-submission/components/credits.tsx
@@ -3,6 +3,7 @@ import { useCallback, useEffect, useState } from 'preact/hooks'
 
 import { equals, uniqueBy } from '../../../common/utils/array'
 import { clsx } from '../../../common/utils/clsx'
+import { forceQuerySelector, waitForResult } from '../../../common/utils/dom'
 import { pipe } from '../../../common/utils/pipe'
 import { ifDefined, isDefined } from '../../../common/utils/types'
 import classes from '../styles/buttons.module.css'
@@ -13,8 +14,62 @@ type Artist = {
   name: string
 }
 
+function useSelectedText() {
+  const [selectedText, setSelectedText] = useState('')
+  const [trackNumber, setTrackNumber] = useState('')
+  useEffect(() => {
+    function handleChange() {
+      setSelectedText(window?.getSelection()?.toString() || '')
+      setTrackNumber(
+        (
+          window?.getSelection()?.anchorNode?.parentElement?.children[1]
+            ?.firstChild as HTMLInputElement
+        )?.value || ''
+      )
+    }
+    window.addEventListener('select', handleChange)
+    handleChange()
+    return () => window.removeEventListener('select', handleChange)
+  }, [])
+  return [selectedText, trackNumber]
+}
+
+const fillArtist = async (
+  artist: string,
+  type: string,
+  trackNumber: string
+) => {
+  // Enter search term
+  forceQuerySelector<HTMLInputElement>(document)('#credit_searchterm').value =
+    artist
+
+  // Click search button
+  forceQuerySelector<HTMLInputElement>(document)(
+    '#section_credits .gosearch input[type=button]'
+  ).click()
+
+  // Wait for results
+  const topResult = await waitForResult(
+    forceQuerySelector<HTMLIFrameElement>(document)('#creditlist')
+  )
+
+  // Click the top result if there is one
+  if (topResult) {
+    topResult.click()
+
+    // Set the other meta
+    forceQuerySelector<HTMLInputElement>(document)(
+      '#creditsx li:last-child .credits_roles input'
+    ).value = type
+    forceQuerySelector<HTMLInputElement>(document)(
+      '#creditsx li:last-child .credits_tracks input'
+    ).value = trackNumber
+  }
+}
+
 export const Credits: FunctionComponent = () => {
   const [filedUnderArtists, setFiledUnderArtists] = useState<Artist[]>([])
+  const [selectedText, trackNumber] = useSelectedText()
   useEffect(() => {
     const observer = new MutationObserver(() => {
       if (!document.body) return
@@ -70,6 +125,15 @@ export const Credits: FunctionComponent = () => {
     []
   )
 
+  const handleCredit = useCallback(
+    (selectedText: string, type: string, trackNumber: string) => {
+      void (async () => {
+        await fillArtist(selectedText, type, trackNumber)
+      })()
+    },
+    []
+  )
+
   return (
     <div className={classes.container}>
       {filedUnderArtists.map((artist) => (
@@ -81,6 +145,28 @@ export const Credits: FunctionComponent = () => {
           onClick={() => handleClick(artist)}
         />
       ))}
+      {selectedText && (
+        <input
+          key={'featured'}
+          type='button'
+          className={clsx('btn', classes.smallButton)}
+          value={`+ featuring ${selectedText}`}
+          onClick={() =>
+            handleCredit(selectedText, 'featured', trackNumber || '')
+          }
+        />
+      )}
+      {selectedText && (
+        <input
+          key={'featured'}
+          type='button'
+          className={clsx('btn', classes.smallButton)}
+          value={`+ remixer ${selectedText}`}
+          onClick={() =>
+            handleCredit(selectedText, 'remixer', trackNumber || '')
+          }
+        />
+      )}
     </div>
   )
 }

--- a/src/modules/release-submission/utils/fillers.ts
+++ b/src/modules/release-submission/utils/fillers.ts
@@ -8,7 +8,7 @@ import {
   ResolveData,
   Track,
 } from '../../../common/services/types'
-import { forceQuerySelector } from '../../../common/utils/dom'
+import { forceQuerySelector, waitForResult } from '../../../common/utils/dom'
 import { FillData } from '../components/dom.d'
 import { CapitalizationType, capitalize } from './capitalization'
 import { ReleaseOptions } from './types'
@@ -151,22 +151,6 @@ const ATTRIBUTE_IDS: Record<ReleaseAttribute, number> = {
   'television soundtrack': 55,
   'video game soundtrack': 56,
 }
-
-const waitForResult = (
-  iframe: HTMLIFrameElement
-): Promise<HTMLDivElement | undefined> =>
-  new Promise((resolve) => {
-    const listener = () => {
-      const firstResult =
-        iframe.contentDocument?.querySelector<HTMLDivElement>('div.result')
-
-      if (firstResult != null) resolve(firstResult)
-      else resolve(undefined)
-
-      iframe.removeEventListener('load', listener)
-    }
-    iframe.addEventListener('load', listener)
-  })
 
 const fillArtist = async (artist: string) => {
   // Enter search term


### PR DESCRIPTION
These are really common, so having a way to add them with a single click is a huge time saver.

By selecting any text within the track list the "+ featured" and "+ remixer" buttons will appear in the "Credits" section. Clicking either of them will perform the search and selection as well as including the role and track number.