### PR TITLE
Spotify & Bandcamp: Fix issue with wrong tracks duration

### DIFF
--- a/src/common/utils/datetime.test.ts
+++ b/src/common/utils/datetime.test.ts
@@ -1,8 +1,10 @@
 import { secondsToString } from './datetime'
 
 describe('secondsToString', () => {
-  test('gets rounding correct', () => {
-    expect(secondsToString(59.4)).toBe('0:59')
-    expect(secondsToString(59.5)).toBe('1:00')
+  test('gets rounding correct (real cases)', () => {
+    expect(secondsToString(60000 / 1000)).toBe('1:00')
+    expect(secondsToString(60440 / 1000)).toBe('1:00')
+    expect(secondsToString(59760 / 1000)).toBe('0:59')
+    expect(secondsToString(59925 / 1000)).toBe('0:59')
   })
 })

--- a/src/common/utils/datetime.ts
+++ b/src/common/utils/datetime.ts
@@ -11,7 +11,6 @@ export const stringToDate = (dateString: string): ReleaseDate => {
 }
 
 export const secondsToString = (seconds: number): string => {
-  seconds = Math.round(seconds)
   const min = Math.floor(seconds / 60)
   const sec = Math.floor(seconds % 60)
   return `${min}:${sec.toString().padStart(2, '0')}`


### PR DESCRIPTION
The issue is described here: https://rateyourmusic.com/list/CaptainMocha/betterrym-browser-extension/