### PR TITLE
fixes remaining update issues, change spotify VA logic

### DIFF
--- a/src/modules/release-submission/use-cases/file-under-controls.tsx
+++ b/src/modules/release-submission/use-cases/file-under-controls.tsx
@@ -6,7 +6,7 @@ import { waitForElement } from '~/common/utils/dom'
 import { selectShortcut } from '../utils/page-functions'
 
 export default async function injectFileUnderControls() {
-  const fileUnder = await waitForElement('#filed_underlist')
+  const fileUnder = await waitForElement('#filed_underperformerlist')
   const unknownArtistDiv = document.createElement('div')
   fileUnder.after(unknownArtistDiv)
   render(<UnknownArtist target='filedunder' />, unknownArtistDiv)

--- a/src/modules/release-submission/utils/fillers.ts
+++ b/src/modules/release-submission/utils/fillers.ts
@@ -76,7 +76,7 @@ async function fillArtists(artists: string[]) {
     forceQuerySelector<HTMLInputElement>(document)('#cat_va').click()
   } else {
     // Regular release
-    if (document.querySelector('.sortable_filed_under') != null) return
+    if (document.querySelector('.sortable_filed_under_performer') != null) return
 
     for (const artist of artists) await fillArtist(artist)
   }


### PR DESCRIPTION
as outlined in #203 this fixes a couple more things broken by the site update and also changes the spotify logic to never add artist names to song titles, but throw an alert for potential VA releases. This makes adding releases with features way less work and doesn't change anything for VA releases since the artist names were unlinked anyways.